### PR TITLE
Issue 94/feature/type aliasses

### DIFF
--- a/src/pilot/sabre_pilot/core.cpp
+++ b/src/pilot/sabre_pilot/core.cpp
@@ -11,8 +11,9 @@ namespace sabre::impl::pilot
     }
 
     sabre::hal::Serial::UniquePtr Factory::createUartObject(
-        uint32_t uartNumber, int32_t baudRate, sabre::hal::PinNumber txPin,
-        sabre::hal::PinNumber rxPin, size_t bufferSize) const
+        sabre::hal::UartNumber uartNumber, sabre::hal::BaudRate baudRate,
+        sabre::hal::PinNumber txPin, sabre::hal::PinNumber rxPin,
+        size_t bufferSize) const
     {
         // Implementation specific code to create a UART object
         return std::make_unique<Serial>(_device, uartNumber, bufferSize);

--- a/src/pilot/sabre_pilot/core.cpp
+++ b/src/pilot/sabre_pilot/core.cpp
@@ -10,10 +10,9 @@ namespace sabre::impl::pilot
                   << std::flush;
     }
 
-    sabre::hal::Serial::UniquePtr
-    Factory::createUartObject(uint32_t uartNumber, int32_t baudRate,
-                              int32_t txPin, int32_t rxPin,
-                              size_t bufferSize) const
+    sabre::hal::Serial::UniquePtr Factory::createUartObject(
+        uint32_t uartNumber, int32_t baudRate, sabre::hal::PinNumber txPin,
+        sabre::hal::PinNumber rxPin, size_t bufferSize) const
     {
         // Implementation specific code to create a UART object
         return std::make_unique<Serial>(_device, uartNumber, bufferSize);
@@ -26,7 +25,8 @@ namespace sabre::impl::pilot
         return nullptr; // Placeholder
     }
 
-    sabre::hal::InputGpio::UniquePtr Factory::createInputGpio(int32_t pin) const
+    sabre::hal::InputGpio::UniquePtr
+    Factory::createInputGpio(sabre::hal::PinNumber pin) const
     {
         std::cout << "Creating InputGPIO on pin " << pin << " for device at "
                   << _device << '\n'
@@ -35,7 +35,7 @@ namespace sabre::impl::pilot
     }
 
     sabre::hal::OutputGpio::UniquePtr
-    Factory::createOutputGpio(int32_t pin) const
+    Factory::createOutputGpio(sabre::hal::PinNumber pin) const
     {
         std::cout << "Creating OutputGPIO on pin " << pin << " for device at "
                   << _device << '\n'
@@ -43,7 +43,8 @@ namespace sabre::impl::pilot
         return std::make_unique<sabre::impl::pilot::OutputGpio>(_device, pin);
     }
 
-    sabre::hal::Gpio::UniquePtr Factory::createGpio(int32_t pin) const
+    sabre::hal::Gpio::UniquePtr
+    Factory::createGpio(sabre::hal::PinNumber pin) const
     {
         std::cout << "Creating generic GPIO on pin " << pin << " for device at "
                   << _device << '\n'

--- a/src/pilot/sabre_pilot/core.hpp
+++ b/src/pilot/sabre_pilot/core.hpp
@@ -13,16 +13,17 @@ namespace sabre::impl::pilot
 
     public:
         Factory(Device *device);
-        sabre::hal::Serial::UniquePtr
-        createUartObject(uint32_t uartNumber, int32_t baudRate, int32_t txPin,
-                         int32_t rxPin, size_t bufferSize) const override;
+        sabre::hal::Serial::UniquePtr createUartObject(
+            uint32_t uartNumber, int32_t baudRate, sabre::hal::PinNumber txPin,
+            sabre::hal::PinNumber rxPin, size_t bufferSize) const override;
         sabre::hal::Serial::UniquePtr
         createUsbCdc(uint32_t index, size_t bufferSize) const override;
         sabre::hal::InputGpio::UniquePtr
-        createInputGpio(int32_t pin) const override;
+        createInputGpio(sabre::hal::PinNumber pin) const override;
         sabre::hal::OutputGpio::UniquePtr
-        createOutputGpio(int32_t pin) const override;
-        sabre::hal::Gpio::UniquePtr createGpio(int32_t pin) const override;
+        createOutputGpio(sabre::hal::PinNumber pin) const override;
+        sabre::hal::Gpio::UniquePtr
+        createGpio(sabre::hal::PinNumber pin) const override;
         sabre::net::WifiStation::UniquePtr createWifiStation() const override;
         sabre::net::WifiSoftAp::UniquePtr createWifiSoftAp() const override;
         sabre::time::WallClock::UniquePtr createWallClock() const override;

--- a/src/pilot/sabre_pilot/core.hpp
+++ b/src/pilot/sabre_pilot/core.hpp
@@ -18,7 +18,8 @@ namespace sabre::impl::pilot
             sabre::hal::PinNumber txPin, sabre::hal::PinNumber rxPin,
             size_t bufferSize) const override;
         sabre::hal::Serial::UniquePtr
-        createUsbCdc(uint32_t index, size_t bufferSize) const override;
+        createUsbCdc(sabre::hal::UsbIndex index,
+                     size_t bufferSize) const override;
         sabre::hal::InputGpio::UniquePtr
         createInputGpio(sabre::hal::PinNumber pin) const override;
         sabre::hal::OutputGpio::UniquePtr

--- a/src/pilot/sabre_pilot/core.hpp
+++ b/src/pilot/sabre_pilot/core.hpp
@@ -14,8 +14,9 @@ namespace sabre::impl::pilot
     public:
         Factory(Device *device);
         sabre::hal::Serial::UniquePtr createUartObject(
-            uint32_t uartNumber, int32_t baudRate, sabre::hal::PinNumber txPin,
-            sabre::hal::PinNumber rxPin, size_t bufferSize) const override;
+            sabre::hal::UartNumber uartNumber, sabre::hal::BaudRate baudRate,
+            sabre::hal::PinNumber txPin, sabre::hal::PinNumber rxPin,
+            size_t bufferSize) const override;
         sabre::hal::Serial::UniquePtr
         createUsbCdc(uint32_t index, size_t bufferSize) const override;
         sabre::hal::InputGpio::UniquePtr

--- a/src/pilot/sabre_pilot/hal.cpp
+++ b/src/pilot/sabre_pilot/hal.cpp
@@ -2,7 +2,8 @@
 
 namespace sabre::impl::pilot
 {
-    Serial::Serial(Device *device, uint32_t number, size_t bufferSize)
+    Serial::Serial(Device *device, sabre::hal::UartNumber number,
+                   size_t bufferSize)
         : _device(device), _uartNumber(number), _bufferSize(bufferSize)
     {
     }
@@ -21,7 +22,8 @@ namespace sabre::impl::pilot
         return 0;      // Success
     }
 
-    std::string Serial::readBytes(size_t maxBytes, uint32_t timeoutInMs)
+    std::string Serial::readBytes(size_t maxBytes,
+                                  sabre::types::MsTime timeoutInMs)
     {
         return _device->read_uart_data(_uartNumber, maxBytes, timeoutInMs);
     }

--- a/src/pilot/sabre_pilot/hal.hpp
+++ b/src/pilot/sabre_pilot/hal.hpp
@@ -14,10 +14,12 @@ namespace sabre::impl::pilot
         size_t _bufferSize;
 
     public:
-        Serial(Device *device, uint32_t number, size_t bufferSize);
+        Serial(Device *device, sabre::hal::UartNumber number,
+               size_t bufferSize);
         void initialize() override;
         int writeByte(char data) const override;
-        std::string readBytes(size_t maxBytes, uint32_t timeoutInMs) override;
+        std::string readBytes(size_t maxBytes,
+                              sabre::types::MsTime timeoutInMs) override;
         void flush() override;
         void deinitialize() override;
     };

--- a/src/pilot/simulator/device.cpp
+++ b/src/pilot/simulator/device.cpp
@@ -6,7 +6,7 @@ namespace sabre::impl::pilot
 {
     DeviceEventData::~DeviceEventData() {}
 
-    UartEventData::UartEventData(uint32_t uartNumber, char data)
+    UartEventData::UartEventData(sabre::hal::UartNumber uartNumber, char data)
         : uartNumber(uartNumber), data(data)
     {
     }
@@ -77,7 +77,8 @@ namespace sabre::impl::pilot
         return gpios;
     }
 
-    bool Device::initialize_uart(uint32_t uartNumber, size_t inputBufferSize)
+    bool Device::initialize_uart(sabre::hal::UartNumber uartNumber,
+                                 size_t inputBufferSize)
     {
         if (uartNumber >= _config.uartCount)
             return false;
@@ -90,7 +91,7 @@ namespace sabre::impl::pilot
         return true;
     }
 
-    bool Device::deinitialize_uart(uint32_t uartNumber)
+    bool Device::deinitialize_uart(sabre::hal::UartNumber uartNumber)
     {
         auto it = _uartMap.find(uartNumber);
         if (it == _uartMap.end())
@@ -100,7 +101,7 @@ namespace sabre::impl::pilot
         return true;
     }
 
-    bool Device::write_uart_data(uint32_t uartNumber, char data)
+    bool Device::write_uart_data(sabre::hal::UartNumber uartNumber, char data)
     {
         auto it = _uartMap.find(uartNumber);
         if (it == _uartMap.end())
@@ -129,7 +130,7 @@ namespace sabre::impl::pilot
         return result;
     }
 
-    void Device::add_to_input_uart_buffer(uint32_t uartNumber,
+    void Device::add_to_input_uart_buffer(sabre::hal::UartNumber uartNumber,
                                           const std::string &data)
     {
         auto it = _uartMap.find(uartNumber);

--- a/src/pilot/simulator/device.cpp
+++ b/src/pilot/simulator/device.cpp
@@ -114,8 +114,9 @@ namespace sabre::impl::pilot
         return true;
     }
 
-    std::string Device::read_uart_data(uint32_t uartNumber, size_t maxBytes,
-                                       uint32_t timeoutInMs)
+    std::string Device::read_uart_data(sabre::hal::UartNumber uartNumber,
+                                       size_t maxBytes,
+                                       sabre::types::MsTime timeoutInMs)
     {
         auto it = _uartMap.find(uartNumber);
         if (it == _uartMap.end())

--- a/src/pilot/simulator/device.hpp
+++ b/src/pilot/simulator/device.hpp
@@ -106,8 +106,9 @@ namespace sabre::impl::pilot
         bool initialize_uart(uint32_t uartNumber, size_t inputBufferSize);
         bool deinitialize_uart(uint32_t uartNumber);
         bool write_uart_data(uint32_t uartNumber, char data);
-        std::string read_uart_data(uint32_t uartNumber, size_t maxBytes,
-                                   uint32_t timeoutInMs);
+        std::string read_uart_data(sabre::hal::UartNumber uartNumber,
+                                   size_t maxBytes,
+                                   sabre::types::MsTime timeoutInMs);
         void add_to_input_uart_buffer(uint32_t uartNumber,
                                       const std::string &data);
         const UARTMap &get_uart_map() const;

--- a/src/pilot/simulator/device.hpp
+++ b/src/pilot/simulator/device.hpp
@@ -21,7 +21,7 @@ namespace sabre::impl::pilot
 
     struct DeviceGPIO
     {
-        uint32_t number;
+        sabre::hal::PinNumber number;
         GPIOType type;
         uint32_t state = 0;
     };
@@ -54,10 +54,10 @@ namespace sabre::impl::pilot
     class UartEventData : public DeviceEventData
     {
     public:
-        uint32_t uartNumber;
+        sabre::hal::UartNumber uartNumber;
         char data;
 
-        UartEventData(uint32_t uartNumber, char data);
+        UartEventData(sabre::hal::UartNumber uartNumber, char data);
     };
 
     struct DeviceEvent
@@ -68,7 +68,7 @@ namespace sabre::impl::pilot
     };
 
     using GPIOVector = std::vector<DeviceGPIO>;
-    using UARTMap = std::map<uint32_t, UartBuffers>;
+    using UARTMap = std::map<sabre::hal::UartNumber, UartBuffers>;
     using DeviceEventCallback = std::function<void(const DeviceEvent &)>;
     using EventCallbacks =
         std::unordered_multimap<DeviceEventType, DeviceEventCallback>;
@@ -103,13 +103,14 @@ namespace sabre::impl::pilot
         GPIOVector get_gpios(GPIOType type) const;
 
         // UART management
-        bool initialize_uart(uint32_t uartNumber, size_t inputBufferSize);
-        bool deinitialize_uart(uint32_t uartNumber);
-        bool write_uart_data(uint32_t uartNumber, char data);
+        bool initialize_uart(sabre::hal::UartNumber uartNumber,
+                             size_t inputBufferSize);
+        bool deinitialize_uart(sabre::hal::UartNumber uartNumber);
+        bool write_uart_data(sabre::hal::UartNumber uartNumber, char data);
         std::string read_uart_data(sabre::hal::UartNumber uartNumber,
                                    size_t maxBytes,
                                    sabre::types::MsTime timeoutInMs);
-        void add_to_input_uart_buffer(uint32_t uartNumber,
+        void add_to_input_uart_buffer(sabre::hal::UartNumber uartNumber,
                                       const std::string &data);
         const UARTMap &get_uart_map() const;
 

--- a/src/sabre/sabre/core/factory.hpp
+++ b/src/sabre/sabre/core/factory.hpp
@@ -51,9 +51,11 @@ namespace sabre::core
          *
          * @return A `Serial::UniquePtr` unique pointer to a `Serial` object.
          */
-        virtual sabre::hal::Serial::UniquePtr createUartObject(
-            uint32_t uartNumber, int32_t baudRate, sabre::hal::PinNumber txPin,
-            sabre::hal::PinNumber rxPin, size_t bufferSize) const = 0;
+        virtual sabre::hal::Serial::UniquePtr
+        createUartObject(sabre::hal::UartNumber uartNumber, int32_t baudRate,
+                         sabre::hal::PinNumber txPin,
+                         sabre::hal::PinNumber rxPin,
+                         size_t bufferSize) const = 0;
 
         /**
          * @brief Create a `Serial` object for USB CDC communication.
@@ -68,7 +70,7 @@ namespace sabre::core
          * @return A `Serial::UniquePtr` unique pointer to a `Serial` object.
          */
         virtual sabre::hal::Serial::UniquePtr
-        createUsbCdc(uint32_t index, size_t bufferSize) const = 0;
+        createUsbCdc(sabre::hal::UsbIndex index, size_t bufferSize) const = 0;
 
         /**
          * @brief Create a `InputGpio` object.

--- a/src/sabre/sabre/core/factory.hpp
+++ b/src/sabre/sabre/core/factory.hpp
@@ -51,11 +51,10 @@ namespace sabre::core
          *
          * @return A `Serial::UniquePtr` unique pointer to a `Serial` object.
          */
-        virtual sabre::hal::Serial::UniquePtr
-        createUartObject(sabre::hal::UartNumber uartNumber, int32_t baudRate,
-                         sabre::hal::PinNumber txPin,
-                         sabre::hal::PinNumber rxPin,
-                         size_t bufferSize) const = 0;
+        virtual sabre::hal::Serial::UniquePtr createUartObject(
+            sabre::hal::UartNumber uartNumber, sabre::hal::BaudRate baudRate,
+            sabre::hal::PinNumber txPin, sabre::hal::PinNumber rxPin,
+            size_t bufferSize) const = 0;
 
         /**
          * @brief Create a `Serial` object for USB CDC communication.
@@ -162,8 +161,9 @@ namespace sabre::core
          * object.
          */
         virtual sabre::utility::WaitFor::UniquePtr
-        createWaitFor(sabre::utility::WaitForPred fn, uint64_t timeoutInMs,
-                      uint64_t sleepTime) const = 0;
+        createWaitFor(sabre::utility::WaitForPred fn,
+                      sabre::types::MsTime timeoutInMs,
+                      sabre::types::MsTime sleepTime) const = 0;
 
         /**
          * @brief Create a `Service` object.

--- a/src/sabre/sabre/core/factory.hpp
+++ b/src/sabre/sabre/core/factory.hpp
@@ -51,9 +51,9 @@ namespace sabre::core
          *
          * @return A `Serial::UniquePtr` unique pointer to a `Serial` object.
          */
-        virtual sabre::hal::Serial::UniquePtr
-        createUartObject(uint32_t uartNumber, int32_t baudRate, int32_t txPin,
-                         int32_t rxPin, size_t bufferSize) const = 0;
+        virtual sabre::hal::Serial::UniquePtr createUartObject(
+            uint32_t uartNumber, int32_t baudRate, sabre::hal::PinNumber txPin,
+            sabre::hal::PinNumber rxPin, size_t bufferSize) const = 0;
 
         /**
          * @brief Create a `Serial` object for USB CDC communication.
@@ -79,7 +79,7 @@ namespace sabre::core
          * object.
          */
         virtual sabre::hal::InputGpio::UniquePtr
-        createInputGpio(int32_t pin) const = 0;
+        createInputGpio(sabre::hal::PinNumber pin) const = 0;
 
         /**
          * @brief Create a `OutputGpio` object.
@@ -90,7 +90,7 @@ namespace sabre::core
          * object.
          */
         virtual sabre::hal::OutputGpio::UniquePtr
-        createOutputGpio(int32_t pin) const = 0;
+        createOutputGpio(sabre::hal::PinNumber pin) const = 0;
 
         /**
          * @brief Create a `Gpio` object.
@@ -100,7 +100,8 @@ namespace sabre::core
          * @return A `GpioUniquePtr` unique pointer to a `Gpio`
          * object.
          */
-        virtual sabre::hal::Gpio::UniquePtr createGpio(int32_t pin) const = 0;
+        virtual sabre::hal::Gpio::UniquePtr
+        createGpio(sabre::hal::PinNumber pin) const = 0;
 
         /**
          * @brief Create a `WifiStation` object.

--- a/src/sabre/sabre/core/gpio_resource_manager.cpp
+++ b/src/sabre/sabre/core/gpio_resource_manager.cpp
@@ -3,31 +3,33 @@
 
 namespace sabre::core
 {
-    GpioResourceManager::GpioResourceManager(Factory &factory,
-                                             int32_t max_gpios) noexcept
+    GpioResourceManager::GpioResourceManager(
+        Factory &factory, sabre::hal::PinNumber max_gpios) noexcept
         : _factory(factory), _upperboundGpio(max_gpios)
     {
     }
 
-    bool GpioResourceManager::_isValidGpio(int32_t pin) const noexcept
+    bool
+    GpioResourceManager::_isValidGpio(sabre::hal::PinNumber pin) const noexcept
     {
         return pin >= 0 && pin <= _upperboundGpio;
     }
 
-    bool GpioResourceManager::_isFreePin(int32_t pin) const noexcept
+    bool
+    GpioResourceManager::_isFreePin(sabre::hal::PinNumber pin) const noexcept
     {
         return _resources.find(pin) == _resources.end();
     }
 
     template <typename T>
-    bool GpioResourceManager::_isType(int32_t pin) const
+    bool GpioResourceManager::_isType(sabre::hal::PinNumber pin) const
     {
         auto it = _resources.find(pin);
         return it != _resources.end() && std::holds_alternative<T>(it->second);
     }
 
     template <typename T, typename FactoryFunc>
-    T &GpioResourceManager::_getOrCreateGpio(int32_t pin,
+    T &GpioResourceManager::_getOrCreateGpio(sabre::hal::PinNumber pin,
                                              FactoryFunc factoryFunc)
     {
         using UniquePtrType = typename T::UniquePtr;
@@ -47,19 +49,21 @@ namespace sabre::core
         throw GpioInUseException("GPIO pin already in use");
     }
 
-    sabre::hal::InputGpio &GpioResourceManager::getInputGpio(int32_t pin)
+    sabre::hal::InputGpio &
+    GpioResourceManager::getInputGpio(sabre::hal::PinNumber pin)
     {
         return _getOrCreateGpio<sabre::hal::InputGpio>(
             pin, [this](int32_t p) { return _factory.createInputGpio(p); });
     }
 
-    sabre::hal::OutputGpio &GpioResourceManager::getOutputGpio(int32_t pin)
+    sabre::hal::OutputGpio &
+    GpioResourceManager::getOutputGpio(sabre::hal::PinNumber pin)
     {
         return _getOrCreateGpio<sabre::hal::OutputGpio>(
             pin, [this](int32_t p) { return _factory.createOutputGpio(p); });
     }
 
-    sabre::hal::Gpio &GpioResourceManager::getGpio(int32_t pin)
+    sabre::hal::Gpio &GpioResourceManager::getGpio(sabre::hal::PinNumber pin)
     {
         return _getOrCreateGpio<sabre::hal::Gpio>(
             pin, [this](int32_t p) { return _factory.createGpio(p); });

--- a/src/sabre/sabre/core/gpio_resource_manager.cpp
+++ b/src/sabre/sabre/core/gpio_resource_manager.cpp
@@ -53,19 +53,22 @@ namespace sabre::core
     GpioResourceManager::getInputGpio(sabre::hal::PinNumber pin)
     {
         return _getOrCreateGpio<sabre::hal::InputGpio>(
-            pin, [this](int32_t p) { return _factory.createInputGpio(p); });
+            pin, [this](sabre::hal::PinNumber p)
+            { return _factory.createInputGpio(p); });
     }
 
     sabre::hal::OutputGpio &
     GpioResourceManager::getOutputGpio(sabre::hal::PinNumber pin)
     {
         return _getOrCreateGpio<sabre::hal::OutputGpio>(
-            pin, [this](int32_t p) { return _factory.createOutputGpio(p); });
+            pin, [this](sabre::hal::PinNumber p)
+            { return _factory.createOutputGpio(p); });
     }
 
     sabre::hal::Gpio &GpioResourceManager::getGpio(sabre::hal::PinNumber pin)
     {
         return _getOrCreateGpio<sabre::hal::Gpio>(
-            pin, [this](int32_t p) { return _factory.createGpio(p); });
+            pin,
+            [this](sabre::hal::PinNumber p) { return _factory.createGpio(p); });
     }
 } // namespace sabre::core

--- a/src/sabre/sabre/core/gpio_resource_manager.hpp
+++ b/src/sabre/sabre/core/gpio_resource_manager.hpp
@@ -22,7 +22,7 @@ namespace sabre::core
         std::unordered_map<sabre::hal::PinNumber, ResourceVariant> _resources;
 
         template <typename T>
-        bool _isType(sabre::hal::PinNumber) const;
+        bool _isType(sabre::hal::PinNumber pin) const;
         template <typename T, typename FactoryFunc>
         T &_getOrCreateGpio(sabre::hal::PinNumber pin, FactoryFunc factoryFunc);
 

--- a/src/sabre/sabre/core/gpio_resource_manager.hpp
+++ b/src/sabre/sabre/core/gpio_resource_manager.hpp
@@ -22,21 +22,22 @@ namespace sabre::core
         std::unordered_map<int32_t, ResourceVariant> _resources;
 
         template <typename T>
-        bool _isType(int32_t pin) const;
+        bool _isType(sabre::hal::PinNumber) const;
         template <typename T, typename FactoryFunc>
-        T &_getOrCreateGpio(int32_t pin, FactoryFunc factoryFunc);
+        T &_getOrCreateGpio(sabre::hal::PinNumber pin, FactoryFunc factoryFunc);
 
-        bool _isFreePin(int32_t pin) const noexcept;
-        bool _isValidGpio(int32_t pin) const noexcept;
+        bool _isFreePin(sabre::hal::PinNumber pin) const noexcept;
+        bool _isValidGpio(sabre::hal::PinNumber pin) const noexcept;
 
     public:
         using Ptr = GpioResourceManager *;
         using SharedPtr = std::shared_ptr<GpioResourceManager>;
         using UniquePtr = std::unique_ptr<GpioResourceManager>;
 
-        GpioResourceManager(Factory &factory, int32_t upperboundGpio) noexcept;
-        sabre::hal::InputGpio &getInputGpio(int32_t pin);
-        sabre::hal::OutputGpio &getOutputGpio(int32_t pin);
-        sabre::hal::Gpio &getGpio(int32_t pin);
+        GpioResourceManager(Factory &factory,
+                            sabre::hal::PinNumber upperboundGpio) noexcept;
+        sabre::hal::InputGpio &getInputGpio(sabre::hal::PinNumber pin);
+        sabre::hal::OutputGpio &getOutputGpio(sabre::hal::PinNumber pin);
+        sabre::hal::Gpio &getGpio(sabre::hal::PinNumber pin);
     };
 } // namespace sabre::core

--- a/src/sabre/sabre/core/gpio_resource_manager.hpp
+++ b/src/sabre/sabre/core/gpio_resource_manager.hpp
@@ -16,10 +16,10 @@ namespace sabre::core
                                              sabre::hal::Gpio::UniquePtr>;
 
     private:
-        int32_t _upperboundGpio;
+        sabre::hal::PinNumber _upperboundGpio;
         Factory &_factory;
 
-        std::unordered_map<int32_t, ResourceVariant> _resources;
+        std::unordered_map<sabre::hal::PinNumber, ResourceVariant> _resources;
 
         template <typename T>
         bool _isType(sabre::hal::PinNumber) const;

--- a/src/sabre/sabre/core/resource_manager.cpp
+++ b/src/sabre/sabre/core/resource_manager.cpp
@@ -2,9 +2,9 @@
 
 namespace sabre::core
 {
-    ResourceManager::ResourceManager(Factory &factory,
-                                     sabre::hal::PinNumber max_gpios,
-                                     uint32_t upperboundUart) noexcept
+    ResourceManager::ResourceManager(
+        Factory &factory, sabre::hal::PinNumber max_gpios,
+        sabre::hal::UartNumber upperboundUart) noexcept
         : _gpio_manager(factory, max_gpios),
           _serial_manager(factory, upperboundUart)
     {

--- a/src/sabre/sabre/core/resource_manager.cpp
+++ b/src/sabre/sabre/core/resource_manager.cpp
@@ -2,7 +2,8 @@
 
 namespace sabre::core
 {
-    ResourceManager::ResourceManager(Factory &factory, int32_t max_gpios,
+    ResourceManager::ResourceManager(Factory &factory,
+                                     sabre::hal::PinNumber max_gpios,
                                      uint32_t upperboundUart) noexcept
         : _gpio_manager(factory, max_gpios),
           _serial_manager(factory, upperboundUart)

--- a/src/sabre/sabre/core/resource_manager.hpp
+++ b/src/sabre/sabre/core/resource_manager.hpp
@@ -23,7 +23,7 @@ namespace sabre::core
          */
         virtual ~ResourceManager() = default;
 
-        ResourceManager(Factory &factory, int32_t max_gpios,
+        ResourceManager(Factory &factory, sabre::hal::PinNumber max_gpios,
                         uint32_t upperboundUart) noexcept;
 
         GpioResourceManager &gpio() noexcept;

--- a/src/sabre/sabre/core/resource_manager.hpp
+++ b/src/sabre/sabre/core/resource_manager.hpp
@@ -24,7 +24,7 @@ namespace sabre::core
         virtual ~ResourceManager() = default;
 
         ResourceManager(Factory &factory, sabre::hal::PinNumber max_gpios,
-                        uint32_t upperboundUart) noexcept;
+                        sabre::hal::UartNumber upperboundUart) noexcept;
 
         GpioResourceManager &gpio() noexcept;
         SerialResourceManager &serial() noexcept;

--- a/src/sabre/sabre/core/serial_resource_manager.cpp
+++ b/src/sabre/sabre/core/serial_resource_manager.cpp
@@ -3,12 +3,12 @@
 namespace sabre::core
 {
     SerialResourceManager::SerialResourceManager(
-        Factory &factory, uint32_t upperboundUart) noexcept
+        Factory &factory, sabre::hal::UartNumber upperboundUart) noexcept
         : _factory(factory), _upperboundUart(upperboundUart)
     {
     }
 
-    void SerialResourceManager::configureUart(uint32_t uartNumber,
+    void SerialResourceManager::configureUart(sabre::hal::UartNumber uartNumber,
                                               int32_t baudRate,
                                               const sabre::hal::Gpio &txPin,
                                               const sabre::hal::Gpio &rxPin,
@@ -31,7 +31,7 @@ namespace sabre::core
     }
 
     sabre::hal::Serial &
-    SerialResourceManager::getUart(uint32_t uartNumber) const
+    SerialResourceManager::getUart(sabre::hal::UartNumber uartNumber) const
     {
         auto it = _uartResources.find(uartNumber);
         if (it == _uartResources.end())
@@ -43,7 +43,7 @@ namespace sabre::core
         return *(it->second);
     }
 
-    void SerialResourceManager::configureUsbCdc(uint32_t index,
+    void SerialResourceManager::configureUsbCdc(sabre::hal::UsbIndex index,
                                                 size_t bufferSize)
     {
         if (_usbCdcResources.find(index) != _usbCdcResources.end())
@@ -55,7 +55,8 @@ namespace sabre::core
         _usbCdcResources[index] = std::move(usbCdc);
     }
 
-    sabre::hal::Serial &SerialResourceManager::getUsbCdc(uint32_t index) const
+    sabre::hal::Serial &
+    SerialResourceManager::getUsbCdc(sabre::hal::UsbIndex index) const
     {
         auto it = _usbCdcResources.find(index);
         if (it == _usbCdcResources.end())

--- a/src/sabre/sabre/core/serial_resource_manager.cpp
+++ b/src/sabre/sabre/core/serial_resource_manager.cpp
@@ -9,7 +9,7 @@ namespace sabre::core
     }
 
     void SerialResourceManager::configureUart(sabre::hal::UartNumber uartNumber,
-                                              int32_t baudRate,
+                                              sabre::hal::BaudRate baudRate,
                                               const sabre::hal::Gpio &txPin,
                                               const sabre::hal::Gpio &rxPin,
                                               size_t bufferSize)

--- a/src/sabre/sabre/core/serial_resource_manager.hpp
+++ b/src/sabre/sabre/core/serial_resource_manager.hpp
@@ -12,9 +12,10 @@ namespace sabre::core
         Factory &_factory;
         uint32_t _upperboundUart;
 
-        std::unordered_map<uint32_t, sabre::hal::Serial::UniquePtr>
+        std::unordered_map<sabre::hal::UartNumber,
+                           sabre::hal::Serial::UniquePtr>
             _uartResources;
-        std::unordered_map<uint32_t, sabre::hal::Serial::UniquePtr>
+        std::unordered_map<sabre::hal::UsbIndex, sabre::hal::Serial::UniquePtr>
             _usbCdcResources;
 
     public:
@@ -23,13 +24,14 @@ namespace sabre::core
         using UniquePtr = std::unique_ptr<SerialResourceManager>;
 
         SerialResourceManager(Factory &factory,
-                              uint32_t upperboundUart) noexcept;
-        void configureUart(uint32_t uartNumber, int32_t baudRate,
+                              sabre::hal::UartNumber upperboundUart) noexcept;
+        void configureUart(sabre::hal::UartNumber uartNumber, int32_t baudRate,
                            const sabre::hal::Gpio &txPin,
                            const sabre::hal::Gpio &rxPin, size_t bufferSize);
-        sabre::hal::Serial &getUart(uint32_t uartNumber) const;
+        sabre::hal::Serial &getUart(sabre::hal::UartNumber uartNumber) const;
 
-        void configureUsbCdc(uint32_t index, size_t bufferSize);
-        sabre::hal::Serial &getUsbCdc(uint32_t index) const;
+        void configureUsbCdc(sabre::hal::UsbIndex index,
+                             sabre::types::MsTime bufferSize);
+        sabre::hal::Serial &getUsbCdc(sabre::hal::UsbIndex index) const;
     };
 } // namespace sabre::core

--- a/src/sabre/sabre/core/serial_resource_manager.hpp
+++ b/src/sabre/sabre/core/serial_resource_manager.hpp
@@ -10,7 +10,7 @@ namespace sabre::core
     {
     private:
         Factory &_factory;
-        uint32_t _upperboundUart;
+        sabre::hal::UartNumber _upperboundUart;
 
         std::unordered_map<sabre::hal::UartNumber,
                            sabre::hal::Serial::UniquePtr>

--- a/src/sabre/sabre/core/serial_resource_manager.hpp
+++ b/src/sabre/sabre/core/serial_resource_manager.hpp
@@ -31,8 +31,7 @@ namespace sabre::core
                            const sabre::hal::Gpio &rxPin, size_t bufferSize);
         sabre::hal::Serial &getUart(sabre::hal::UartNumber uartNumber) const;
 
-        void configureUsbCdc(sabre::hal::UsbIndex index,
-                             sabre::types::MsTime bufferSize);
+        void configureUsbCdc(sabre::hal::UsbIndex index, size_t bufferSize);
         sabre::hal::Serial &getUsbCdc(sabre::hal::UsbIndex index) const;
     };
 } // namespace sabre::core

--- a/src/sabre/sabre/core/serial_resource_manager.hpp
+++ b/src/sabre/sabre/core/serial_resource_manager.hpp
@@ -25,7 +25,8 @@ namespace sabre::core
 
         SerialResourceManager(Factory &factory,
                               sabre::hal::UartNumber upperboundUart) noexcept;
-        void configureUart(sabre::hal::UartNumber uartNumber, int32_t baudRate,
+        void configureUart(sabre::hal::UartNumber uartNumber,
+                           sabre::hal::BaudRate baudRate,
                            const sabre::hal::Gpio &txPin,
                            const sabre::hal::Gpio &rxPin, size_t bufferSize);
         sabre::hal::Serial &getUart(sabre::hal::UartNumber uartNumber) const;

--- a/src/sabre/sabre/hal/gpio.cpp
+++ b/src/sabre/sabre/hal/gpio.cpp
@@ -2,9 +2,9 @@
 
 namespace sabre::hal
 {
-    Gpio::Gpio(int32_t pinNumber) noexcept : _pinNumber(pinNumber) {}
+    Gpio::Gpio(PinNumber pinNumber) noexcept : _pinNumber(pinNumber) {}
 
-    int32_t Gpio::getPinNumber() const noexcept
+    PinNumber Gpio::getPinNumber() const noexcept
     {
         return _pinNumber;
     }

--- a/src/sabre/sabre/hal/gpio.hpp
+++ b/src/sabre/sabre/hal/gpio.hpp
@@ -4,7 +4,7 @@
 
 namespace sabre::hal
 {
-    using PinNumber = uint32_t;
+    using PinNumber = int32_t;
     /**
      * @brief Base class for Gpio operations.
      *

--- a/src/sabre/sabre/hal/gpio.hpp
+++ b/src/sabre/sabre/hal/gpio.hpp
@@ -4,6 +4,7 @@
 
 namespace sabre::hal
 {
+    using PinNumber = uint32_t;
     /**
      * @brief Base class for Gpio operations.
      *
@@ -13,7 +14,7 @@ namespace sabre::hal
     class Gpio
     {
     private:
-        int32_t _pinNumber = 0;
+        PinNumber _pinNumber = 0;
 
     public:
         using Ptr = Gpio *;
@@ -22,8 +23,8 @@ namespace sabre::hal
 
     public:
         Gpio() noexcept = default;
-        Gpio(int32_t pinNumber) noexcept;
-        int32_t getPinNumber() const noexcept;
+        Gpio(PinNumber pinNumber) noexcept;
+        PinNumber getPinNumber() const noexcept;
 
         /**
          * @brief Virtual destructor.

--- a/src/sabre/sabre/hal/serial.hpp
+++ b/src/sabre/sabre/hal/serial.hpp
@@ -9,6 +9,8 @@ namespace sabre::hal
 {
     using UartNumber = uint32_t;
     using UsbIndex = uint32_t;
+    using BaudRate = uint32_t;
+
     /**
      * @brief Abstract base class for Serial communication.
      *

--- a/src/sabre/sabre/hal/serial.hpp
+++ b/src/sabre/sabre/hal/serial.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
+#include "../types/types.hpp"
 #include <cstddef> // For size_t
 #include <cstdint> // For uint32_t
 #include <memory>
 
 namespace sabre::hal
 {
+    using UartNumber = uint32_t;
+    using UsbIndex = uint32_t;
     /**
      * @brief Abstract base class for Serial communication.
      *
@@ -60,7 +63,7 @@ namespace sabre::hal
          * @return A string containing the received data.
          */
         virtual std::string readBytes(size_t maxBytes,
-                                      uint32_t timeoutInMs) = 0;
+                                      sabre::types::MsTime timeoutInMs) = 0;
 
         /**
          * @brief Flush the output buffer of the Serial device.

--- a/src/sabre/sabre/time/wall_clock.hpp
+++ b/src/sabre/sabre/time/wall_clock.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../types/types.hpp"
 #include <cstdint>
 #include <memory>
 

--- a/src/sabre/sabre/time/wall_clock.hpp
+++ b/src/sabre/sabre/time/wall_clock.hpp
@@ -28,7 +28,7 @@ namespace sabre::time
          *
          * @return The current time since 1970-01-01 00:00:00 in milliseconds.
          */
-        virtual uint64_t nowMs() const noexcept = 0;
+        virtual sabre::types::MsTime nowMs() const noexcept = 0;
 
         /**
          * @brief Set the current time in ms since 1970-01-01
@@ -36,6 +36,6 @@ namespace sabre::time
          * @param timeInMs The time to set in milliseconds since 1970-01-01
          * 00:00:00.
          */
-        virtual void setNowMs(uint64_t timeInMs) = 0;
+        virtual void setNowMs(sabre::types::MsTime timeInMs) = 0;
     };
 } // namespace sabre::time

--- a/src/sabre/sabre/types/types.hpp
+++ b/src/sabre/sabre/types/types.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+
+namespace sabre
+{
+    namespace types
+    {
+        using MsTime = uint64_t;
+    }
+} // namespace sabre

--- a/src/sabre/sabre/utility/wait_for.cpp
+++ b/src/sabre/sabre/utility/wait_for.cpp
@@ -3,22 +3,22 @@
 namespace sabre::utility
 {
 
-    bool WaitFor::_done(bool result, uint64_t totalRuntime) noexcept
+    bool WaitFor::_done(bool result, sabre::types::MsTime totalRuntime) noexcept
     {
         _runtime = totalRuntime;
         _result = result;
         return result;
     }
 
-    WaitFor::WaitFor(const WaitForPred &fn, uint64_t timeoutInMs,
-                     uint64_t sleepTime)
+    WaitFor::WaitFor(const WaitForPred &fn, sabre::types::MsTime timeoutInMs,
+                     sabre::types::MsTime sleepTime)
         : _timeoutInMs(timeoutInMs), _fn(fn), _sleepTime(sleepTime)
     {
     }
 
     bool WaitFor::operator()()
     {
-        uint64_t starttime = _getCurrentTime();
+        sabre::types::MsTime starttime = _getCurrentTime();
 
         while (_timeoutInMs > _getCurrentTime() - starttime)
         {
@@ -34,7 +34,7 @@ namespace sabre::utility
         return _result;
     }
 
-    uint64_t WaitFor::getResultRuntime() const noexcept
+    sabre::types::MsTime WaitFor::getResultRuntime() const noexcept
     {
         return _runtime;
     }

--- a/src/sabre/sabre/utility/wait_for.hpp
+++ b/src/sabre/sabre/utility/wait_for.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../types/types.hpp"
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -24,15 +25,15 @@ namespace sabre::utility
         using UniquePtr = std::unique_ptr<WaitFor>;
 
     private:
-        bool _done(bool result, uint64_t totalRuntime) noexcept;
+        bool _done(bool result, sabre::types::MsTime totalRuntime) noexcept;
 
     protected:
-        uint64_t _timeoutInMs;
+        sabre::types::MsTime _timeoutInMs;
         WaitForPred _fn;
-        uint64_t _sleepTime = 0;
+        sabre::types::MsTime _sleepTime = 0;
 
         bool _result = false;
-        uint64_t _runtime = 0;
+        sabre::types::MsTime _runtime = 0;
 
         /**
          * @brief Get the current time in milliseconds.
@@ -41,7 +42,7 @@ namespace sabre::utility
          * the current time in milliseconds since the epoch or a similar
          * reference point.
          */
-        virtual uint64_t _getCurrentTime() const noexcept = 0;
+        virtual sabre::types::MsTime _getCurrentTime() const noexcept = 0;
 
         /**
          * @brief Sleep for a specified duration.
@@ -60,8 +61,8 @@ namespace sabre::utility
          * @param timeoutInMs The maximum time to wait in milliseconds.
          * @param sleepTime The time to sleep between checks in milliseconds.
          */
-        WaitFor(const WaitForPred &fn, uint64_t timeoutInMs,
-                uint64_t sleepTime);
+        WaitFor(const WaitForPred &fn, sabre::types::MsTime timeoutInMs,
+                sabre::types::MsTime sleepTime);
 
         /**
          * @brief Virtual destructor.
@@ -98,6 +99,6 @@ namespace sabre::utility
          *
          * @return The runtime in milliseconds.
          */
-        uint64_t getResultRuntime() const noexcept;
+        sabre::types::MsTime getResultRuntime() const noexcept;
     };
 }; // namespace sabre::utility

--- a/tests/sabre_test_mocks/sabre_test_mocks/core.cpp
+++ b/tests/sabre_test_mocks/sabre_test_mocks/core.cpp
@@ -9,8 +9,9 @@ namespace sabre::impl::sabre_test_mocks
     }
 
     sabre::hal::Serial::UniquePtr StFactory::createUartObject(
-        uint32_t uartNumber, int32_t baudRate, sabre::hal::PinNumber txPin,
-        sabre::hal::PinNumber rxPin, size_t bufferSize) const
+        sabre::hal::UartNumber uartNumber, sabre::hal::BaudRate baudRate,
+        sabre::hal::PinNumber txPin, sabre::hal::PinNumber rxPin,
+        size_t bufferSize) const
     {
         if (_uart_should_be_nullptr)
             return nullptr;

--- a/tests/sabre_test_mocks/sabre_test_mocks/core.cpp
+++ b/tests/sabre_test_mocks/sabre_test_mocks/core.cpp
@@ -8,10 +8,9 @@ namespace sabre::impl::sabre_test_mocks
     {
     }
 
-    sabre::hal::Serial::UniquePtr
-    StFactory::createUartObject(uint32_t uartNumber, int32_t baudRate,
-                                int32_t txPin, int32_t rxPin,
-                                size_t bufferSize) const
+    sabre::hal::Serial::UniquePtr StFactory::createUartObject(
+        uint32_t uartNumber, int32_t baudRate, sabre::hal::PinNumber txPin,
+        sabre::hal::PinNumber rxPin, size_t bufferSize) const
     {
         if (_uart_should_be_nullptr)
             return nullptr;
@@ -27,18 +26,19 @@ namespace sabre::impl::sabre_test_mocks
     }
 
     sabre::hal::InputGpio::UniquePtr
-    StFactory::createInputGpio(int32_t pin) const
+    StFactory::createInputGpio(sabre::hal::PinNumber pin) const
     {
         return std::make_unique<sabre::impl::sabre_test_mocks::StInputGpio>();
     }
 
     sabre::hal::OutputGpio::UniquePtr
-    StFactory::createOutputGpio(int32_t pin) const
+    StFactory::createOutputGpio(sabre::hal::PinNumber pin) const
     {
         return std::make_unique<sabre::impl::sabre_test_mocks::StOutputGpio>();
     }
 
-    sabre::hal::Gpio::UniquePtr StFactory::createGpio(int32_t pin) const
+    sabre::hal::Gpio::UniquePtr
+    StFactory::createGpio(sabre::hal::PinNumber pin) const
     {
         return std::make_unique<sabre::impl::sabre_test_mocks::StGpio>(pin);
     }

--- a/tests/sabre_test_mocks/sabre_test_mocks/core.cpp
+++ b/tests/sabre_test_mocks/sabre_test_mocks/core.cpp
@@ -18,7 +18,7 @@ namespace sabre::impl::sabre_test_mocks
     }
 
     sabre::hal::Serial::UniquePtr
-    StFactory::createUsbCdc(uint32_t index, size_t bufferSize) const
+    StFactory::createUsbCdc(sabre::hal::UsbIndex index, size_t bufferSize) const
     {
         if (_uart_should_be_nullptr)
             return nullptr;

--- a/tests/sabre_test_mocks/sabre_test_mocks/core.hpp
+++ b/tests/sabre_test_mocks/sabre_test_mocks/core.hpp
@@ -17,7 +17,8 @@ namespace sabre::impl::sabre_test_mocks
             sabre::hal::PinNumber txPin, sabre::hal::PinNumber rxPin,
             size_t bufferSize) const override;
         sabre::hal::Serial::UniquePtr
-        createUsbCdc(uint32_t index, size_t bufferSize) const override;
+        createUsbCdc(sabre::hal::UsbIndex index,
+                     size_t bufferSize) const override;
         sabre::hal::InputGpio::UniquePtr
         createInputGpio(sabre::hal::PinNumber pin) const override;
         sabre::hal::OutputGpio::UniquePtr

--- a/tests/sabre_test_mocks/sabre_test_mocks/core.hpp
+++ b/tests/sabre_test_mocks/sabre_test_mocks/core.hpp
@@ -13,8 +13,9 @@ namespace sabre::impl::sabre_test_mocks
     public:
         StFactory(bool uartShouldBeNullptr = false);
         sabre::hal::Serial::UniquePtr createUartObject(
-            uint32_t uartNumber, int32_t baudRate, sabre::hal::PinNumber txPin,
-            sabre::hal::PinNumber rxPin, size_t bufferSize) const override;
+            sabre::hal::UartNumber uartNumber, sabre::hal::BaudRate baudRate,
+            sabre::hal::PinNumber txPin, sabre::hal::PinNumber rxPin,
+            size_t bufferSize) const override;
         sabre::hal::Serial::UniquePtr
         createUsbCdc(uint32_t index, size_t bufferSize) const override;
         sabre::hal::InputGpio::UniquePtr

--- a/tests/sabre_test_mocks/sabre_test_mocks/core.hpp
+++ b/tests/sabre_test_mocks/sabre_test_mocks/core.hpp
@@ -12,16 +12,17 @@ namespace sabre::impl::sabre_test_mocks
 
     public:
         StFactory(bool uartShouldBeNullptr = false);
-        sabre::hal::Serial::UniquePtr
-        createUartObject(uint32_t uartNumber, int32_t baudRate, int32_t txPin,
-                         int32_t rxPin, size_t bufferSize) const override;
+        sabre::hal::Serial::UniquePtr createUartObject(
+            uint32_t uartNumber, int32_t baudRate, sabre::hal::PinNumber txPin,
+            sabre::hal::PinNumber rxPin, size_t bufferSize) const override;
         sabre::hal::Serial::UniquePtr
         createUsbCdc(uint32_t index, size_t bufferSize) const override;
         sabre::hal::InputGpio::UniquePtr
-        createInputGpio(int32_t pin) const override;
+        createInputGpio(sabre::hal::PinNumber pin) const override;
         sabre::hal::OutputGpio::UniquePtr
-        createOutputGpio(int32_t pin) const override;
-        sabre::hal::Gpio::UniquePtr createGpio(int32_t pin) const override;
+        createOutputGpio(sabre::hal::PinNumber pin) const override;
+        sabre::hal::Gpio::UniquePtr
+        createGpio(sabre::hal::PinNumber pin) const override;
         sabre::net::WifiStation::UniquePtr createWifiStation() const override;
         sabre::net::WifiSoftAp::UniquePtr createWifiSoftAp() const override;
         sabre::net::MqttClient::UniquePtr createMqttClient() const override;

--- a/tests/sabre_test_mocks/sabre_test_mocks/hal.hpp
+++ b/tests/sabre_test_mocks/sabre_test_mocks/hal.hpp
@@ -46,7 +46,8 @@ namespace sabre::impl::sabre_test_mocks
     public:
         void initialize();
         int writeByte(char data) const;
-        std::string readBytes(size_t maxBytes, uint32_t timeoutMs) override;
+        std::string readBytes(size_t maxBytes,
+                              sabre::types::MsTime timeoutMs) override;
         void flush();
         void deinitialize();
 

--- a/tests/sabre_test_mocks/sabre_test_mocks/hall.cpp
+++ b/tests/sabre_test_mocks/sabre_test_mocks/hall.cpp
@@ -34,7 +34,8 @@ namespace sabre::impl::sabre_test_mocks
         return static_cast<int>(data);
     }
 
-    std::string TestUART::readBytes(size_t maxBytes, uint32_t timeoutMs)
+    std::string TestUART::readBytes(size_t maxBytes,
+                                    sabre::types::MsTime timeoutMs)
     {
         // For testing purposes, return up to maxBytes from the buffer
         std::string result = _buf.substr(0, maxBytes);


### PR DESCRIPTION
The goal of this change is to make sure we don't use primitives for domain specific types, like pin numbers for Gpio's and numbers for Uart ports. By doing this, the users of the library can have a better understanding of what is required when using the library.