### PR TITLE
fix: Update method signatures for `std::string`.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,7 @@
 {
     "name": "Sabre",
-    "image": "dast1986/slough-dev-dc-cpp:1.0.0",
+    "image": "dast1986/slough-dev-dc-cpp:1.0.1",
     "remoteEnv": {
-        "PROMPTNAME": "Sabre",
-        "LIBGL_ALWAYS_SOFTWARE": "1"
-    },
-    "postCreateCommand": "sudo apt update && sudo apt install -y libglfw3-dev ninja-build"
+        "PROMPTNAME": "Sabre"
+    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Sabre",
-    "image": "dast1986/slough-dev-dc-cpp:1.0.1",
+    "image": "dast1986/slough-dev-dc-cpp:1.0.2",
     "remoteEnv": {
         "PROMPTNAME": "Sabre"
     }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,16 +13,6 @@
             },
             "group": "none",
             "problemMatcher": []
-        },
-        {
-            "type": "shell",
-            "label": "Remove all ImGui configuration",
-            "command": "find -name imgui.ini -exec rm {} \\;",
-            "options": {
-                "cwd": "${workspaceFolder}"
-            },
-            "group": "none",
-            "problemMatcher": []
         }
     ]
 }

--- a/src/sabre/sabre/core/exceptions.cpp
+++ b/src/sabre/sabre/core/exceptions.cpp
@@ -31,4 +31,28 @@ namespace sabre::core
     ApiError::ApiError(const std::string &msg) : SabreException(msg) {}
 
     ApiError::ApiError() : SabreException("Unknown API error") {}
+
+    UartNotConfiguredException::UartNotConfiguredException(
+        const std::string &message)
+        : ResourceManagerException(message)
+    {
+    }
+
+    UsbCdcNotConfiguredException::UsbCdcNotConfiguredException(
+        const std::string &message)
+        : ResourceManagerException(message)
+    {
+    }
+
+    NtpClientAlreadyConfiguredException::NtpClientAlreadyConfiguredException(
+        const std::string &message)
+        : ResourceManagerException(message)
+    {
+    }
+
+    NtpClientNotConfiguredException::NtpClientNotConfiguredException(
+        const std::string &message)
+        : ResourceManagerException(message)
+    {
+    }
 } // namespace sabre::core

--- a/src/sabre/sabre/core/exceptions.hpp
+++ b/src/sabre/sabre/core/exceptions.hpp
@@ -47,6 +47,31 @@ namespace sabre::core
         explicit LogHandlerNotAvailableException(const std::string &message);
     };
 
+    class UartNotConfiguredException : public ResourceManagerException
+    {
+    public:
+        explicit UartNotConfiguredException(const std::string &message);
+    };
+
+    class UsbCdcNotConfiguredException : public ResourceManagerException
+    {
+    public:
+        explicit UsbCdcNotConfiguredException(const std::string &message);
+    };
+
+    class NtpClientAlreadyConfiguredException : public ResourceManagerException
+    {
+    public:
+        explicit NtpClientAlreadyConfiguredException(
+            const std::string &message);
+    };
+
+    class NtpClientNotConfiguredException : public ResourceManagerException
+    {
+    public:
+        explicit NtpClientNotConfiguredException(const std::string &message);
+    };
+
     /**
      * @brief Exception thrown by implementation on API errors.
      *

--- a/src/sabre/sabre/core/serial_resource_manager.cpp
+++ b/src/sabre/sabre/core/serial_resource_manager.cpp
@@ -1,4 +1,5 @@
 #include "serial_resource_manager.hpp"
+#include "exceptions.hpp"
 
 namespace sabre::core
 {
@@ -40,9 +41,9 @@ namespace sabre::core
         auto it = _uartResources.find(uartNumber);
         if (it == _uartResources.end())
         {
-            // TODO: Custom exception
-            throw std::runtime_error("UART not configured. Please configure it "
-                                     "first using the configureUart method.");
+            throw UartNotConfiguredException(
+                "UART not configured. Please configure it "
+                "first using the configureUart method.");
         }
         return *(it->second);
     }
@@ -88,8 +89,7 @@ namespace sabre::core
         auto it = _usbCdcResources.find(index);
         if (it == _usbCdcResources.end())
         {
-            // TODO: Custom exception
-            throw std::runtime_error(
+            throw UsbCdcNotConfiguredException(
                 "USB CDC not configured. Please configure it "
                 "first using the configureUsbCdc method.");
         }

--- a/src/sabre/sabre/core/time_resource_manager.cpp
+++ b/src/sabre/sabre/core/time_resource_manager.cpp
@@ -1,4 +1,5 @@
 #include "time_resource_manager.hpp"
+#include "exceptions.hpp"
 
 namespace sabre::core
 {
@@ -24,9 +25,8 @@ namespace sabre::core
         auto it = _ntpClients.find(identifier);
         if (it != _ntpClients.end())
         {
-            // TODO: Custom exception
-            throw std::runtime_error("NtpClient " + identifier +
-                                     " is already configured");
+            throw NtpClientAlreadyConfiguredException(
+                "NtpClient " + identifier + " is already configured");
         }
         _ntpClients[identifier] = _factory.createNtpClient(server);
         _ntpClients[identifier]->getLogHelper().createLogger(
@@ -39,9 +39,8 @@ namespace sabre::core
         auto it = _ntpClients.find(identifier);
         if (it == _ntpClients.end())
         {
-            // TODO: Custom exception
-            throw std::runtime_error("NtpClient " + identifier +
-                                     " is not configured yet.");
+            throw NtpClientNotConfiguredException("NtpClient " + identifier +
+                                                  " is not configured yet.");
         }
         return *it->second;
     }

--- a/src/sabre/sabre/log/logging.cpp
+++ b/src/sabre/sabre/log/logging.cpp
@@ -57,7 +57,6 @@ namespace sabre::log
     {
         if (_handlers.find(identifier) == _handlers.end())
         {
-            // TODO: Custom exception
             throw sabre::core::LogHandlerNotAvailableException(
                 "LogHandler not available");
         }

--- a/src/sabre/sabre/models/net.cpp
+++ b/src/sabre/sabre/models/net.cpp
@@ -32,7 +32,7 @@ namespace sabre::models::net
             result += std::to_string((*this)[i]);
         }
         return result;
-    }
+    } // LCOV_EXCL_LINE
 
     std::ostream &operator<<(std::ostream &os, const IPv4Address &ipv4)
     {

--- a/src/sabre/sabre/net/wifi_soft_ap.hpp
+++ b/src/sabre/sabre/net/wifi_soft_ap.hpp
@@ -40,7 +40,8 @@ namespace sabre::net
          * @param ssid The SSID of the Wi-Fi network.
          * @param password The password for the Wi-Fi network.
          */
-        virtual void start(std::string ssid, std::string password) = 0;
+        virtual void start(const std::string &ssid,
+                           const std::string &password) = 0;
 
         /**
          * @brief Stop the Wi-Fi Soft AP.

--- a/src/sabre/sabre/parsers/gps.cpp
+++ b/src/sabre/sabre/parsers/gps.cpp
@@ -54,7 +54,7 @@ namespace sabre::parsers
         fields.push_back(scentence.substr(start));
 
         return fields;
-    }
+    } // LCOV_EXCL_LINE
 
     // Helper to parse coordinates from NMEA fields
     bool NmeaParser::_extractPositionFromFields(
@@ -84,7 +84,7 @@ namespace sabre::parsers
         double lon_min = std::stod(lon_str.substr(3));
         char lon_dir = fields[lon_dir_idx][0];
 
-        out_position = models::geo::Position(
+        out_position = models::geo::Position( // LCOV_EXCL_LINE
             models::geo::Coordinate(lat_deg, lat_min, dir_map.at(lat_dir)),
             models::geo::Coordinate(lon_deg, lon_min, dir_map.at(lon_dir)));
         return true;

--- a/src/sabre/sabre/parsers/nmea_validator.cpp
+++ b/src/sabre/sabre/parsers/nmea_validator.cpp
@@ -8,7 +8,7 @@ namespace sabre::parsers
         _NmeaSentence.reserve(82);
     }
 
-    NmeaValidator::~NmeaValidator() noexcept {}
+    NmeaValidator::~NmeaValidator() noexcept {} // LCOV_EXCL_LINE
 
     void NmeaValidator::addCharacter(char character)
     {

--- a/tests/sabre_test_mocks/sabre_test_mocks/net.cpp
+++ b/tests/sabre_test_mocks/sabre_test_mocks/net.cpp
@@ -59,7 +59,10 @@ namespace sabre::impl::sabre_test_mocks
 
     void StWifiSoftAp::init() {}
 
-    void StWifiSoftAp::start(std::string ssid, std::string password) {}
+    void StWifiSoftAp::start(const std::string &ssid,
+                             const std::string &password)
+    {
+    }
 
     void StWifiSoftAp::stop() {}
 

--- a/tests/sabre_test_mocks/sabre_test_mocks/net.hpp
+++ b/tests/sabre_test_mocks/sabre_test_mocks/net.hpp
@@ -50,7 +50,7 @@ namespace sabre::impl::sabre_test_mocks
     {
     public:
         void init();
-        void start(std::string ssid, std::string password);
+        void start(const std::string &ssid, const std::string &password);
         void stop();
         void deinitialize();
     };

--- a/tests/sabre_tests/test_parsers.cpp
+++ b/tests/sabre_tests/test_parsers.cpp
@@ -126,7 +126,7 @@ TEST(ParsersNMEA, InvalidRMC)
 TEST(ParsersNMEA, VoidGLL)
 {
     NmeaParser parser;
-    parser.addSentence("$GNGLL,3409.3251,N,11849.1290,W,120000.00,V,A*2A");
+    parser.addSentence("$GNGLL,3409.3251,N,11849.1290,W,120000.00,V*18");
     parser.parse();
     ASSERT_FALSE(parser.getLastPosition().isValid());
 }
@@ -148,6 +148,15 @@ TEST(ParsersNMEA, VoidGGA)
     ASSERT_FALSE(parser.getLastPosition().isValid());
 }
 
+TEST(ParsersNMEA, InvalidFieldSize)
+{
+    NmeaParser parser;
+    parser.addSentence("$GNGGA,120000.00,3409.3251,N,11849.1290,W,0,08,0.9,"
+                       "100.0,M,-34.0,M,*60");
+    parser.parse();
+    ASSERT_FALSE(parser.getLastPosition().isValid());
+}
+
 TEST(ParsersNMEA, InvalidGGA)
 {
     NmeaParser parser;
@@ -161,6 +170,24 @@ TEST(ParsersNMEA, InvalidChecksum)
 {
     NmeaParser parser;
     parser.addSentence("$GNGGA,120000.00,3409.3251,N,11849.1290,W,1,08,0.9,"
+                       "100.0,M,-34.0,M,,*AA");
+    parser.parse();
+    ASSERT_FALSE(parser.getLastPosition().isValid());
+}
+
+TEST(ParsersNMEA, InvalidChecksumToLittleFields)
+{
+    NmeaParser parser;
+    parser.addSentence("$GNGGA,3409.3251,N,11849.1290,W,1,08,0.9,"
+                       "100.0,M,-34.0,M,,*AA");
+    parser.parse();
+    ASSERT_FALSE(parser.getLastPosition().isValid());
+}
+
+TEST(ParsersNMEA, InvalidChecksumNoDollarSign)
+{
+    NmeaParser parser;
+    parser.addSentence("GNGGA,3409.3251,N,11849.1290,W,1,08,0.9,"
                        "100.0,M,-34.0,M,,*AA");
     parser.parse();
     ASSERT_FALSE(parser.getLastPosition().isValid());


### PR DESCRIPTION
The arguments now mention `const std::string&` instead of `std::string` to avoid unneeded copies.

Fixes #136